### PR TITLE
Add QT Py to boards

### DIFF
--- a/boards/qtpy/board.h
+++ b/boards/qtpy/board.h
@@ -1,0 +1,29 @@
+// Copyright 2019 Katherine J. Temkin <kate@ktemkin.com>
+// Copyright 2019 Great Scott Gadgets <ktemkin@greatscottgadgets.com>
+// Copyright 2014 Technical Machine, Inc. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#ifndef __BOARD_H__
+#define __BOARD_H__
+
+// Buttons.
+const static Pin RECOVERY_BUTTON = {.group = 0, .pin = 00, .mux = 0 }; // unused on QT Py
+
+// LEDs.
+const static Pin LED_PIN         = {.group = 0, .pin = 01, .mux = 0 }; // unused on QT Py
+
+// USB pins
+const static Pin PIN_USB_DM      = {.group = 0, .pin = 24, .mux = MUX_PA24G_USB_DM };
+const static Pin PIN_USB_DP      = {.group = 0, .pin = 25, .mux = MUX_PA25G_USB_DP };
+
+// the size of the original uf2 bootlaoder is 8k
+// thus firmware expects to start at 8k
+#define FLASH_BOOT_SIZE 8192
+
+#endif

--- a/boards/qtpy/board.mk
+++ b/boards/qtpy/board.mk
@@ -1,0 +1,5 @@
+
+# Hardware configuration. Not so critical. I suspect binary would not change
+# for any value here in the D21 family.
+PART = SAMD21E18A
+

--- a/common/board.h
+++ b/common/board.h
@@ -7,12 +7,16 @@
 #include "common/util.h"
 #include "common/hw.h"
 
+#include <board.h>
+
 // Memory Layout
 // - first 4k reserved for DAFU Bootloader
 // - remainder of flash for main firmware
 //
 #define FLASH_BOOT_START 	0
+#ifndef FLASH_BOOT_SIZE
 #define FLASH_BOOT_SIZE 	4096
+#endif
 
 // Calcuated at runtime, based on chip's report of it's size.
 extern uint32_t 			total_flash_size;

--- a/main.c
+++ b/main.c
@@ -18,7 +18,7 @@
 #include "boot.h"
 #include "common/nvm.h"
 
-#include <board.h>
+#include "common/board.h"
 
 __attribute__ ((section(".copyright")))
 __attribute__ ((used))


### PR DESCRIPTION
QT Py ships with uf2 bootloader pre-installed.
Since this takes up 8k in flash, most firmware for the QT Py is linked
to start at 8k.
These changes make the FLASH_BOOT_SIZE configurable in the board.h of
the boards and adds the QT Py.