### PR TITLE
Binary size optimization: saturn-v under 2 KiB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,20 @@
 
 BOARD ?= luna_d11
 
+# These should default to the latest revision; but can be set on the command line.
+BOARD_REVISION_MAJOR ?= 1
+BOARD_REVISION_MINOR ?= 0
+
+# On r0.1 or r0.2 boards, we want to target the SAMD21 / luna_d21 configuration.
+ifeq ($(BOARD_REVISION_MAJOR), 0)
+	ifeq ($(BOARD_REVISION_MINOR), 1)
+		BOARD := luna_d21
+	endif
+	ifeq ($(BOARD_REVISION_MINOR), 2)
+		BOARD := luna_d21
+	endif
+endif
+
 CROSS=arm-none-eabi-
 
 # Toolchain
@@ -34,11 +48,12 @@ CFLAGS = -Wall --std=gnu99 -Os -g3 -nostartfiles -fno-builtin \
 
 # USB PID/VID and other branding values
 CFLAGS += \
-			-D USB_PRODUCT_ID=0x7551 \
-			-D USB_VENDOR_ID=0x1209 \
+			-D USB_PRODUCT_ID=0x615c \
+			-D USB_VENDOR_ID=0x1d50 \
 			-D USB_MANUFACTURER_STR='"Great Scott Gadgets"' \
 			-D USB_PRODUCT_STR='"LUNA Saturn-V RCM Bootloader"' \
-			-D COPYRIGHT_NOTE='"Visit https://githib.com/opendime/DAFU"' \
+			-D_BOARD_REVISION_MAJOR_=$(BOARD_REVISION_MAJOR) \
+			-D_BOARD_REVISION_MINOR_=$(BOARD_REVISION_MINOR)
 
 # Header file search path
 PRJ_PATH = deps

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ include boards/$(BOARD)/board.mk
 
 
 # Compiler flags.
-CFLAGS = -Wall --std=gnu99 -Os -g3 \
+CFLAGS = -Wall --std=gnu99 -Os -g3 -nostartfiles \
 			-flto -fdata-sections -ffunction-sections -funsigned-char -funsigned-bitfields \
 			-mcpu=cortex-m0plus -mthumb -D __$(PART)__ -I . -Iboards/$(BOARD)
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ include boards/$(BOARD)/board.mk
 
 
 # Compiler flags.
-CFLAGS = -Wall --std=gnu99 -Os -g3 -nostartfiles \
+CFLAGS = -Wall --std=gnu99 -Os -g3 -nostartfiles -fno-builtin \
 			-flto -fdata-sections -ffunction-sections -funsigned-char -funsigned-bitfields \
 			-mcpu=cortex-m0plus -mthumb -D __$(PART)__ -I . -Iboards/$(BOARD)
 

--- a/boards/luna_d11/board.h
+++ b/boards/luna_d11/board.h
@@ -13,7 +13,13 @@
 #define __BOARD_H__
 
 // Buttons.
+#if ((_BOARD_REVISION_MAJOR_ == 0) && (_BOARD_REVISION_MINOR_ < 6))
 const static Pin RECOVERY_BUTTON = {.group = 0, .pin = 16, .mux = 0 };
+#else
+const static Pin RECOVERY_BUTTON = {.group = 0, .pin = 2, .mux = 0 };
+// USB switch
+const static Pin USB_SWITCH      = {.group = 0, .pin = 6, .mux = 0 };
+#endif
 
 // LEDs.
 const static Pin LED_PIN         = {.group = 0, .pin = 22, .mux = 0 };
@@ -21,6 +27,5 @@ const static Pin LED_PIN         = {.group = 0, .pin = 22, .mux = 0 };
 // USB pins
 const static Pin PIN_USB_DM      = {.group = 0, .pin = 24, .mux = MUX_PA24G_USB_DM };
 const static Pin PIN_USB_DP      = {.group = 0, .pin = 25, .mux = MUX_PA25G_USB_DP };
-
 
 #endif

--- a/common/board.h
+++ b/common/board.h
@@ -8,11 +8,11 @@
 #include "common/hw.h"
 
 // Memory Layout
-// - first 4k reserved for DAFU Bootloader
+// - first 2k reserved for Saturn-V Bootloader
 // - remainder of flash for main firmware
 //
 #define FLASH_BOOT_START 	0
-#define FLASH_BOOT_SIZE 	4096
+#define FLASH_BOOT_SIZE 	2048
 
 #define FLASH_FW_START 		FLASH_BOOT_SIZE
 #define FLASH_FW_SIZE 		(FLASH_SIZE - FLASH_BOOT_SIZE)

--- a/common/board.h
+++ b/common/board.h
@@ -14,11 +14,8 @@
 #define FLASH_BOOT_START 	0
 #define FLASH_BOOT_SIZE 	4096
 
-// Calcuated at runtime, based on chip's report of it's size.
-extern uint32_t 			total_flash_size;
-
 #define FLASH_FW_START 		FLASH_BOOT_SIZE
-#define FLASH_FW_SIZE 		(total_flash_size - FLASH_BOOT_SIZE)
+#define FLASH_FW_SIZE 		(FLASH_SIZE - FLASH_BOOT_SIZE)
 
 #define FLASH_BOOT_ADDR 	FLASH_BOOT_START
 #define FLASH_FW_ADDR 		FLASH_FW_START

--- a/common/hw.h
+++ b/common/hw.h
@@ -10,6 +10,31 @@
 
 const extern char *git_version;
 
+inline static void pins_wrconfig(uint8_t group, uint32_t pin_mask, uint32_t flags) {
+  if (pin_mask & 0xFFFF0000UL) {
+    PORT->Group[group].WRCONFIG.reg = PORT_WRCONFIG_WRPINCFG | PORT_WRCONFIG_HWSEL | 
+                                      flags | PORT_WRCONFIG_PINMASK(pin_mask >> 16);
+  }
+  if (pin_mask & 0x0000FFFFUL) {
+    PORT->Group[group].WRCONFIG.reg = PORT_WRCONFIG_WRPINCFG | flags | 
+                                      PORT_WRCONFIG_PINMASK(pin_mask & 0xFFFF);
+  }
+}
+
+inline static void pins_out(uint8_t group, uint32_t pin_mask, uint32_t flags) {
+  pins_wrconfig(group, pin_mask, flags);
+  PORT->Group[group].DIRSET.reg = pin_mask;
+}
+
+inline static void pins_in(uint8_t group, uint32_t pin_mask, uint32_t flags) {
+  pins_wrconfig(group, pin_mask, flags);
+  PORT->Group[group].DIRCLR.reg = pin_mask;
+}
+
+inline static void pins_high(uint8_t group, uint32_t pin_mask) {
+  PORT->Group[group].OUTSET.reg = pin_mask;
+}
+
 inline static void pin_mux(Pin p) {
   if (p.pin & 1) {
     PORT->Group[p.group].PMUX[p.pin/2].bit.PMUXO = p.mux;

--- a/common/nvm.h
+++ b/common/nvm.h
@@ -12,7 +12,6 @@ uint32_t nvm_flash_size() {
 }
 
 void nvm_init() {
-  NVMCTRL->CTRLB.bit.MANW = 1;
 }
 
 void nvm_address(uint32_t addr) {
@@ -34,14 +33,11 @@ void nvm_erase_row(uint32_t addr) {
 }
 
 void nvm_write_page(uint32_t addr, uint8_t* buf, uint8_t len) {
-  uint32_t nvm_addr = addr/2;
-
+  uint32_t nvm_addr = addr >> 1;
+  uint16_t *src = (uint16_t*)buf;
   // NVM must be accessed as a series of 16-bit words
-  for (uint16_t i = 0; i < len; i += 2) {
-    uint16_t data = buf[i];
-    if (i < (len - 1)) data |= (buf[i + 1] << 8);
-
-    NVM_MEMORY[nvm_addr++] = data;
+  for (uint16_t i = 0; i < (len >> 1); i++) {
+    NVM_MEMORY[nvm_addr++] = src[i];
   }
 
   /* Perform a manual NVM write when the length of data to be programmed is

--- a/common/startup_samd21.c
+++ b/common/startup_samd21.c
@@ -161,33 +161,12 @@ const DeviceVectors exception_table = {
  */
 void Reset_Handler(void)
 {
-        uint32_t *pSrc, *pDest;
-
-        /* Initialize the relocate segment */
-        pSrc = &_etext;
-        pDest = &_srelocate;
-
-#if 0
-		// See link-script.ld which makes sure we dont need this.
-
-        if (pSrc != pDest) {
-                for (; pDest < &_erelocate;) {
-                        *pDest++ = *pSrc++;
-                }
-        }
-#endif
+        uint32_t *pDest;
 
         /* Clear the zero segment */
         for (pDest = &_szero; pDest < &_ezero;) {
                 *pDest++ = 0;
         }
-
-        /* Set the vector table base address */
-        pSrc = (uint32_t *) & _sfixed;
-        SCB->VTOR = ((uint32_t) pSrc & SCB_VTOR_TBLOFF_Msk);
-
-        /* Initialize the C library */
-        __libc_init_array();
 
         /* Branch to main function */
         main_bl();

--- a/common/startup_samd21.c
+++ b/common/startup_samd21.c
@@ -103,8 +103,7 @@ void I2S_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler
 /* Exception Table */
 __attribute__ ((section(".vectors")))
 __attribute__ ((used))
-const DeviceVectors exception_table = {
-
+void (* const exception_table[])(void) = {
         /* Configure Initial Stack Pointer, using linker-generated symbols */
         (void*) (&_estack),
 
@@ -133,26 +132,7 @@ const DeviceVectors exception_table = {
         (void*) NVMCTRL_Handler,        /*  5 Non-Volatile Memory Controller */
         (void*) DMAC_Handler,           /*  6 Direct Memory Access Controller */
         (void*) USB_Handler,            /*  7 Universal Serial Bus */
-        (void*) EVSYS_Handler,          /*  8 Event System Interface */
-        (void*) SERCOM0_Handler,        /*  9 Serial Communication Interface 0 */
-        (void*) SERCOM1_Handler,        /* 10 Serial Communication Interface 1 */
-        (void*) SERCOM2_Handler,        /* 11 Serial Communication Interface 2 */
-        (void*) SERCOM3_Handler,        /* 12 Serial Communication Interface 3 */
-        (void*) SERCOM4_Handler,        /* 13 Serial Communication Interface 4 */
-        (void*) SERCOM5_Handler,        /* 14 Serial Communication Interface 5 */
-        (void*) TCC0_Handler,           /* 15 Timer Counter Control 0 */
-        (void*) TCC1_Handler,           /* 16 Timer Counter Control 1 */
-        (void*) TCC2_Handler,           /* 17 Timer Counter Control 2 */
-        (void*) TC3_Handler,            /* 18 Basic Timer Counter 0 */
-        (void*) TC4_Handler,            /* 19 Basic Timer Counter 1 */
-        (void*) TC5_Handler,            /* 20 Basic Timer Counter 2 */
-        (void*) TC6_Handler,            /* 21 Basic Timer Counter 3 */
-        (void*) TC7_Handler,            /* 22 Basic Timer Counter 4 */
-        (void*) ADC_Handler,            /* 23 Analog Digital Converter */
-        (void*) AC_Handler,             /* 24 Analog Comparators */
-        (void*) DAC_Handler,            /* 25 Digital Analog Converter */
-        (void*) PTC_Handler,            /* 26 Peripheral Touch Controller */
-        (void*) I2S_Handler             /* 27 Inter-IC Sound Interface */
+        // Size optimization: ignore rest of handlers
 };
 
 /**

--- a/deps/usb/class/dfu/dfu.c
+++ b/deps/usb/class/dfu/dfu.c
@@ -2,7 +2,7 @@
 
 DFU_State dfu_state;
 DFU_Status dfu_status;
-uint16_t dfu_poll_timeout;
+uint16_t dfu_poll_timeout = 0;
 uint16_t dfu_block_offset;
 
 void dfu_control_setup() {
@@ -68,7 +68,6 @@ void dfu_error(uint8_t status) {
 void dfu_reset() {
 	dfu_state = DFU_STATE_dfuIDLE;
 	dfu_status = DFU_STATUS_OK;
-	dfu_poll_timeout = 0;
 }
 
 void dfu_control_out_completion() {
@@ -81,8 +80,8 @@ void dfu_control_out_completion() {
 			dfu_block_offset += USB_EP0_SIZE;
 
 			if (dfu_block_offset >= usb_setup.wLength) {
-				dfu_poll_timeout = dfu_cb_dnload_block_completed(usb_setup.wValue, usb_setup.wLength);
-				if (dfu_poll_timeout == 0 && dfu_status == DFU_STATUS_OK) {
+				dfu_cb_dnload_block_completed(usb_setup.wValue, usb_setup.wLength);
+				if (dfu_status == DFU_STATUS_OK) {
 					dfu_state = DFU_STATE_dfuDNLOAD_IDLE;
 					usb_ep0_in(0);
 				}

--- a/deps/usb/samd/usb_samd.c
+++ b/deps/usb/samd/usb_samd.c
@@ -59,7 +59,6 @@ void usb_init(){
 
 	USB->DEVICE.PADCAL.reg = USB_PADCAL_TRANSN(pad_transn) | USB_PADCAL_TRANSP(pad_transp) | USB_PADCAL_TRIM(pad_trim);
 
-	memset(usb_endpoints, 0, usb_num_endpoints*sizeof(UsbDeviceDescriptor));
 	USB->DEVICE.DESCADD.reg = (uint32_t)(&usb_endpoints[0]);
 	USB->DEVICE.INTENSET.reg = USB_DEVICE_INTENSET_EORST;
 

--- a/deps/usb/samd/usb_samd.h
+++ b/deps/usb/samd/usb_samd.h
@@ -11,4 +11,4 @@ extern const uint8_t usb_num_endpoints;
 
 #define USB_ENDPOINTS(NUM_EP) \
 	const uint8_t usb_num_endpoints = (NUM_EP); \
-	UsbDeviceDescriptor usb_endpoints[(NUM_EP)+1];
+	UsbDeviceDescriptor usb_endpoints[(NUM_EP)+1] = {0};

--- a/deps/usb/usb_requests.c
+++ b/deps/usb/usb_requests.c
@@ -5,27 +5,6 @@ __attribute__((__aligned__(4))) uint8_t ep0_buf_in[USB_EP0_SIZE];
 __attribute__((__aligned__(4))) uint8_t ep0_buf_out[USB_EP0_SIZE];
 volatile uint8_t usb_configuration;
 
-uint16_t usb_ep0_in_size;
-const uint8_t* usb_ep0_in_ptr;
-
-void usb_ep0_in_multi() {
-	uint16_t tsize = usb_ep0_in_size;
-
-	if (tsize > USB_EP0_SIZE) {
-		tsize = USB_EP0_SIZE;
-	}
-
-	memcpy(ep0_buf_in, usb_ep0_in_ptr, tsize);
-	usb_ep_start_in(0x80, ep0_buf_in, tsize, false);
-
-	if (tsize == 0) {
-		usb_ep0_out();
-	}
-
-	usb_ep0_in_size -= tsize;
-	usb_ep0_in_ptr += tsize;
-}
-
 void usb_handle_setup(void){
 	if ((usb_setup.bmRequestType & USB_REQTYPE_TYPE_MASK) == USB_REQTYPE_STANDARD){
 		switch (usb_setup.bRequest){
@@ -37,9 +16,6 @@ void usb_handle_setup(void){
 
 			case USB_REQ_ClearFeature:
 			case USB_REQ_SetFeature:
-				usb_ep0_in(0);
-				return usb_ep0_out();
-
 			case USB_REQ_SetAddress:
 				usb_ep0_in(0);
 				return usb_ep0_out();
@@ -54,17 +30,9 @@ void usb_handle_setup(void){
 					if (size > usb_setup.wLength) {
 						size = usb_setup.wLength;
 					}
-
-					if (descriptor == ep0_buf_in) {
-						usb_ep0_in_size = 0;
-						usb_ep_start_in(0x80, ep0_buf_in, size, true);
-					} else {
-						usb_ep0_in_size = size;
-						usb_ep0_in_ptr = descriptor;
-						usb_ep0_in_multi();
-					}
-
-					return;
+					memcpy(ep0_buf_in, descriptor, size);
+					usb_ep_start_in(0x80, ep0_buf_in, size, false);
+					return usb_ep0_out();
 				} else {
 					return usb_ep0_stall();
 				}
@@ -112,9 +80,6 @@ void usb_handle_control_in_complete(void) {
 		switch (usb_setup.bRequest){
 			case USB_REQ_SetAddress:
 				usb_set_address(usb_setup.wValue & 0x7F);
-				return;
-			case USB_REQ_GetDescriptor:
-				usb_ep0_in_multi();
 				return;
 		}
 	} else {

--- a/link-script.ld
+++ b/link-script.ld
@@ -88,11 +88,17 @@ SECTIONS
         KEEP (*(.preinit_array))
         __preinit_array_end = .;
 
+        ASSERT(__preinit_array_end == __preinit_array_start,
+                    "No support for preinit section");
+
         . = ALIGN(4);
         __init_array_start = .;
         KEEP (*(SORT(.init_array.*)))
         KEEP (*(.init_array))
         __init_array_end = .;
+
+        ASSERT(__init_array_end == __init_array_start,
+                    "No support for init section");
 
         . = ALIGN(4);
         KEEP (*crtbegin.o(.ctors))
@@ -108,6 +114,9 @@ SECTIONS
         KEEP (*(.fini_array))
         KEEP (*(SORT(.fini_array.*)))
         __fini_array_end = .;
+
+        ASSERT(__fini_array_end == __fini_array_start,
+                    "No support for fini section");
 
         KEEP (*crtbegin.o(.dtors))
         KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))

--- a/link-script.ld
+++ b/link-script.ld
@@ -54,7 +54,7 @@ SEARCH_DIR(.)
 /* Memory Spaces Definitions */
 MEMORY
 {
-  rom    (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00001000
+  rom    (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00000800
   ram    (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00001000
 }
 

--- a/main.c
+++ b/main.c
@@ -73,8 +73,12 @@ void bootloader_main(void)
 
 	__enable_irq();
 
-	pin_mux(PIN_USB_DM);
-	pin_mux(PIN_USB_DP);
+	// Configure USB pins
+	PORT->Group[0].WRCONFIG.reg = PORT_WRCONFIG_HWSEL | PORT_WRCONFIG_WRPINCFG | 
+							      PORT_WRCONFIG_WRPMUX | PORT_WRCONFIG_PMUXEN | 
+								  PORT_WRCONFIG_PMUX(PORT_PMUX_PMUXE_G_Val) | 
+								  PORT_WRCONFIG_PINMASK(0x0300);
+
 	usb_init();
 	usb_attach();
 
@@ -110,8 +114,11 @@ bool bootloader_sw_triggered(void)
 
 bool button_pressed(void)
 {
-	pin_pull_up(RECOVERY_BUTTON);
-
+	PORT->Group[0].WRCONFIG.reg = PORT_WRCONFIG_HWSEL | PORT_WRCONFIG_WRPINCFG | 
+								  PORT_WRCONFIG_INEN | PORT_WRCONFIG_PULLEN | 
+								  PORT_WRCONFIG_PINMASK(1 << (RECOVERY_BUTTON.pin - 16));
+	PORT->Group[0].DIRCLR.reg = (1<<RECOVERY_BUTTON.pin);
+	PORT->Group[0].OUTSET.reg = (1<<RECOVERY_BUTTON.pin);
 
 	// Drop into Recovery Mode if the recovery button is presssed.
 	if (pin_read(RECOVERY_BUTTON) == 0) {

--- a/main.c
+++ b/main.c
@@ -31,7 +31,7 @@ uint32_t total_flash_size;
 
 /*** SysTick ***/
 
-volatile uint32_t g_msTicks;
+volatile uint32_t g_msTicks = 0;
 
 /* SysTick IRQ handler */
 void SysTick_Handler(void) {
@@ -50,7 +50,6 @@ void init_systick(void) {
 		while (1) {}								/* Capture error */
 	}
 	NVIC_SetPriority(SysTick_IRQn, 0x0);
-	g_msTicks = 0;
 }
 
 /*** USB / DFU ***/

--- a/main.c
+++ b/main.c
@@ -139,7 +139,6 @@ bool bootloader_sw_triggered(void)
 
 bool button_pressed(void)
 {
-	pin_in(RECOVERY_BUTTON);
 	pin_pull_up(RECOVERY_BUTTON);
 
 

--- a/main.c
+++ b/main.c
@@ -20,10 +20,6 @@
 
 #include <board.h>
 
-__attribute__ ((section(".copyright")))
-__attribute__ ((used))
-const char copyright_note[] = COPYRIGHT_NOTE;
-
 volatile bool exit_and_jump = 0;
 
 /*** SysTick ***/

--- a/main.c
+++ b/main.c
@@ -99,9 +99,7 @@ void bootloader_main(void)
 
 	// Blink while we're in DFU mode.
 	while(!exit_and_jump) {
-		pin_high(LED_PIN);
-		delay_ms(300);
-		pin_low(LED_PIN);
+		pin_toggle(LED_PIN);
 		delay_ms(300);
 	}
 

--- a/main.c
+++ b/main.c
@@ -65,9 +65,8 @@ void noopFunction(void)
 
 void bootloader_main(void)
 {
-	// Turn on the LED that indicates we're in bootloader mode.
+	// Set up the LED that indicates we're in bootloader mode.
 	pin_out(LED_PIN);
-	pin_low(LED_PIN);
 
 	// Set up the main clocks.
 	clock_init_usb(GCLK_SYSTEM);

--- a/main.c
+++ b/main.c
@@ -101,7 +101,7 @@ bool flash_valid() {
 	unsigned ip = ((unsigned *)FLASH_FW_ADDR)[1];
 
 	return     sp > 0x20000000
-			&& ip >= 0x00001000
+			&& ip >= FLASH_FW_START
 			&& ip <  0x00400000;
 }
 

--- a/main.c
+++ b/main.c
@@ -26,9 +26,6 @@ const char copyright_note[] = COPYRIGHT_NOTE;
 
 volatile bool exit_and_jump = 0;
 
-// set at runtime
-uint32_t total_flash_size;
-
 /*** SysTick ***/
 
 volatile uint32_t g_msTicks = 0;
@@ -86,21 +83,8 @@ void noopFunction(void)
 	// Placeholder function for code that isn't needed. Keep empty!
 }
 
-static void hardware_detect(void)
-{
-	// what kind of chip are we installed on?
-	// .. don't care
-
-	// how big is the flash tho
-	uint16_t page_size = 1 << (NVMCTRL->PARAM.bit.PSZ + 3);
-
-	total_flash_size = NVMCTRL->PARAM.bit.NVMP * page_size;
-}
-
 void bootloader_main(void)
 {
-	hardware_detect();
-
 	// Turn on the LED that indicates we're in bootloader mode.
 	pin_out(LED_PIN);
 	pin_low(LED_PIN);

--- a/main.c
+++ b/main.c
@@ -65,6 +65,12 @@ void noopFunction(void)
 
 void bootloader_main(void)
 {
+#if (((_BOARD_REVISION_MAJOR_ == 0) && (_BOARD_REVISION_MINOR_ >= 6)) || (_BOARD_REVISION_MAJOR_ == 1))
+	// Take over USB port in board revisions >0.6
+	pin_out(USB_SWITCH);
+	pin_high(USB_SWITCH);
+#endif
+
 	// Set up the LED that indicates we're in bootloader mode.
 	pin_out(LED_PIN);
 
@@ -73,7 +79,7 @@ void bootloader_main(void)
 
 	__enable_irq();
 
-	// Configure USB pins
+	// Configure USB pins (24 and 25)
 	PORT->Group[0].WRCONFIG.reg = PORT_WRCONFIG_HWSEL | PORT_WRCONFIG_WRPINCFG | 
 							      PORT_WRCONFIG_WRPMUX | PORT_WRCONFIG_PMUXEN | 
 								  PORT_WRCONFIG_PMUX(PORT_PMUX_PMUXE_G_Val) | 
@@ -114,9 +120,16 @@ bool bootloader_sw_triggered(void)
 
 bool button_pressed(void)
 {
+	// Configure RECOVERY button
+#if ((_BOARD_REVISION_MAJOR_ == 0) && (_BOARD_REVISION_MINOR_ < 6))
 	PORT->Group[0].WRCONFIG.reg = PORT_WRCONFIG_HWSEL | PORT_WRCONFIG_WRPINCFG | 
 								  PORT_WRCONFIG_INEN | PORT_WRCONFIG_PULLEN | 
 								  PORT_WRCONFIG_PINMASK(1 << (RECOVERY_BUTTON.pin - 16));
+#else
+	PORT->Group[0].WRCONFIG.reg = PORT_WRCONFIG_WRPINCFG | 
+								  PORT_WRCONFIG_INEN | 
+								  PORT_WRCONFIG_PINMASK(1 << RECOVERY_BUTTON.pin);
+#endif
 	PORT->Group[0].DIRCLR.reg = (1<<RECOVERY_BUTTON.pin);
 	PORT->Group[0].OUTSET.reg = (1<<RECOVERY_BUTTON.pin);
 

--- a/main.c
+++ b/main.c
@@ -70,7 +70,6 @@ void bootloader_main(void)
 
 	// Set up the main clocks.
 	clock_init_usb(GCLK_SYSTEM);
-	nvm_init();
 
 	__enable_irq();
 

--- a/usb.c
+++ b/usb.c
@@ -124,7 +124,7 @@ uint16_t usb_cb_get_descriptor(uint8_t type, uint8_t index, const uint8_t** ptr)
 			address = &configuration_descriptor;
 			size    = sizeof(ConfigDesc);
 			break;
-		case USB_DTYPE_String:
+		case USB_DTYPE_String: {
 			char *string = NULL;
 			uint8_t string_len;
 			switch (index) {
@@ -154,6 +154,7 @@ uint16_t usb_cb_get_descriptor(uint8_t type, uint8_t index, const uint8_t** ptr)
 			address = str_to_descriptor(string, string_len);
 			size = (((USB_StringDescriptor*)address))->bLength;
 			break;
+		}
 	}
 
 	_exit:

--- a/usb.c
+++ b/usb.c
@@ -11,9 +11,8 @@
 #include "usb.h"
 #include "samd/usb_samd.h"
 
-// Return a ptr to a descriptor, perhaps made with usb_string_to_descriptor()
-// that contains a unique serial number for this board.
-void* get_serial_number_string_descriptor();
+// Return a string that contains a unique serial number for this board.
+char* get_serial_number_string();
 
 USB_ENDPOINTS(1);
 
@@ -42,8 +41,6 @@ typedef struct ConfigDesc {
 	USB_ConfigurationDescriptor Config;
 	USB_InterfaceDescriptor dfu_intf_flash;
 	DFU_FunctionalDescriptor dfu_desc_flash;
-	USB_InterfaceDescriptor dfu_intf_ram;
-	DFU_FunctionalDescriptor dfu_desc_ram;
 } ConfigDesc;
 
 const ConfigDesc configuration_descriptor = {
@@ -66,28 +63,9 @@ const ConfigDesc configuration_descriptor = {
 		.bInterfaceClass = DFU_INTERFACE_CLASS,
 		.bInterfaceSubClass = DFU_INTERFACE_SUBCLASS,
 		.bInterfaceProtocol = DFU_INTERFACE_PROTOCOL,
-		.iInterface = 0x10
+		.iInterface = 0x02
 	},
 	.dfu_desc_flash = {
-		.bLength = sizeof(DFU_FunctionalDescriptor),
-		.bDescriptorType = DFU_DESCRIPTOR_TYPE,
-		.bmAttributes = DFU_ATTR_CAN_DOWNLOAD | DFU_ATTR_WILL_DETACH,
-		.wDetachTimeout = 0,
-		.wTransferSize = DFU_TRANSFER_SIZE,
-		.bcdDFUVersion = 0x0101,
-	},
-	.dfu_intf_ram = {
-		.bLength = sizeof(USB_InterfaceDescriptor),
-		.bDescriptorType = USB_DTYPE_Interface,
-		.bInterfaceNumber = 0,
-		.bAlternateSetting = 1,
-		.bNumEndpoints = 0,
-		.bInterfaceClass = DFU_INTERFACE_CLASS,
-		.bInterfaceSubClass = DFU_INTERFACE_SUBCLASS,
-		.bInterfaceProtocol = DFU_INTERFACE_PROTOCOL,
-		.iInterface = 0x11
-	},
-	.dfu_desc_ram = {
 		.bLength = sizeof(DFU_FunctionalDescriptor),
 		.bDescriptorType = DFU_DESCRIPTOR_TYPE,
 		.bmAttributes = DFU_ATTR_CAN_DOWNLOAD | DFU_ATTR_WILL_DETACH,
@@ -101,12 +79,6 @@ const USB_StringDescriptor language_string = {
 	.bLength = USB_STRING_LEN(1),
 	.bDescriptorType = USB_DTYPE_String,
 	.bString = {USB_LANGUAGE_EN_US},
-};
-
-const USB_StringDescriptor msft_os = {
-	.bLength = 18,
-	.bDescriptorType = USB_DTYPE_String,
-	.bString = {'M','S','F','T','1','0','0',0xee},
 };
 
 const USB_MicrosoftCompatibleDescriptor msft_compatible = {
@@ -126,6 +98,19 @@ const USB_MicrosoftCompatibleDescriptor msft_compatible = {
 	}
 };
 
+
+void* str_to_descriptor(char* str, uint8_t len) {
+	USB_StringDescriptor* desc = (((USB_StringDescriptor*)ep0_buf_in));
+	desc->bLength = USB_STRING_LEN(len);
+	desc->bDescriptorType = USB_DTYPE_String;
+	for (int i=0; i<len; i++) {
+		desc->bString[i] = str[i];
+	}
+	return desc;
+}
+
+#define STRLEN(x) ((sizeof(x)/sizeof(x[0])) - 1)
+
 uint16_t usb_cb_get_descriptor(uint8_t type, uint8_t index, const uint8_t** ptr) {
 	const void* address = NULL;
 	uint16_t size    = 0;
@@ -140,36 +125,38 @@ uint16_t usb_cb_get_descriptor(uint8_t type, uint8_t index, const uint8_t** ptr)
 			size    = sizeof(ConfigDesc);
 			break;
 		case USB_DTYPE_String:
+			char *string = NULL;
+			uint8_t string_len;
 			switch (index) {
 				case 0x00:
 					address = &language_string;
-					break;
+					size = language_string.bLength;
+					goto _exit;
 				case 0x01:
-					address = usb_string_to_descriptor(USB_MANUFACTURER_STR);
+					string = USB_MANUFACTURER_STR;
+					string_len = STRLEN(USB_MANUFACTURER_STR);
 					break;
 				case 0x02:
-					address = usb_string_to_descriptor(USB_PRODUCT_STR);
+					string = USB_PRODUCT_STR;
+					string_len = STRLEN(USB_PRODUCT_STR);
 					break;
 				case 0x03:
-					address = get_serial_number_string_descriptor();
-					break;
-				case 0x10:
-					address = usb_string_to_descriptor("Flash");
-					break;
-				case 0x11:
-					address = usb_string_to_descriptor("SRAM");
-					break;
-				case 0xf0:
-					address = usb_string_to_descriptor("");
+					string = get_serial_number_string();
+					string_len = 26;
 					break;
 				case 0xee:
-					address = &msft_os;
+					string = "MSFT100\xee";
+					string_len = 8;
 					break;
+				default:
+					goto _exit;
 			}
+			address = str_to_descriptor(string, string_len);
 			size = (((USB_StringDescriptor*)address))->bLength;
 			break;
 	}
 
+	_exit:
 	*ptr = address;
 	return size;
 }
@@ -230,32 +217,19 @@ bool usb_cb_set_interface(uint16_t interface, uint16_t altsetting) {
 	return false;
 }
 
-// Return a string descriptor containing a unique serial number.
-//
-void *get_serial_number_string_descriptor()
+/**
+ * Returns a string that describes this device's unique ID.
+ */
+char *get_serial_number_string(void)
 {
-#if 0
-	char buf[27];
-
-	const unsigned char* id = (unsigned char*) 0x0080A00C;
-	for (int i=0; i<26; i++) {
-		unsigned idx = (i*5)/8;
-		unsigned pos = (i*5)%8;
-		unsigned val = ((id[idx] >> pos) | (id[idx+1] << (8-pos))) & ((1<<5)-1);
-		buf[i] = "0123456789ABCDFGHJKLMNPQRSTVWXYZ"[val];
-	}
-	buf[26] = 0;
-#endif
-
-	//
-	// Read and save the device serial number as normal Base32.
-	//
-
 	// Documented in section 9.3.3 of D21 datasheet, page 32 (rev G), but no header file,
 	// these are not contiguous addresses.
 	const uint32_t	*ser[4] = {
-		 	(uint32_t *)0x0080A00C,
-			(uint32_t *)0x0080A040, (uint32_t *)0x0080A044, (uint32_t *)0x0080A048 };
+		(uint32_t *)0x0080A00C,
+		(uint32_t *)0x0080A040,
+		(uint32_t *)0x0080A044,
+		(uint32_t *)0x0080A048
+	};
 
 	uint32_t copy[5];
 	copy[0] = *ser[0];
@@ -283,6 +257,6 @@ void *get_serial_number_string_descriptor()
 		buf[count] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"[index];
 	}
 
-	return usb_string_to_descriptor(buf);
-}
+	return buf;
 
+}

--- a/usb.c
+++ b/usb.c
@@ -257,39 +257,31 @@ void *get_serial_number_string_descriptor()
 		 	(uint32_t *)0x0080A00C,
 			(uint32_t *)0x0080A040, (uint32_t *)0x0080A044, (uint32_t *)0x0080A048 };
 
-	uint32_t copy[4];
+	uint32_t copy[5];
 	copy[0] = *ser[0];
 	copy[1] = *ser[1];
 	copy[2] = *ser[2];
 	copy[3] = *ser[3];
+	copy[4] = 0;
 
 	uint8_t *tmp = (uint8_t *)copy;
 
-	int count = 0;
     int next = 1;
 	int buffer = tmp[0];
     int bitsLeft = 8;
 
-	const int length = 16;
-	char buf[27];
+	static char buf[27] = {0};
 
-	while(bitsLeft > 0 || next < length) {
-		if(bitsLeft < 5) {
-			if(next < length) {
-				buffer <<= 8;
-				buffer |= tmp[next++] & 0xff;
-				bitsLeft += 8;
-			} else {
-				int pad = 5 - bitsLeft;
-				buffer <<= pad;
-				bitsLeft += pad;
-			}
+	for (int count = 0; count < 26; ++count) {
+		if (bitsLeft < 5) {
+			buffer <<= 8;
+			buffer |= tmp[next++] & 0xff;
+			bitsLeft += 8;
 		}
 		bitsLeft -= 5;
 		int index = (buffer >> bitsLeft) & 0x1f;
-		buf[count++] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"[index];
+		buf[count] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"[index];
 	}
-	buf[count] = 0;
 
 	return usb_string_to_descriptor(buf);
 }


### PR DESCRIPTION
This patch set aims to reduce the saturn-v binary size to under 2 KiB in size.

Apollo must be modified to target a 2 KiB offset. Also, its binary size must be an even number.

Support for board revisions >=0.6 is also added. For earlier board revisions, make sure BOARD_REVISION_MAJOR and BOARD_REVISION_MINOR are set in your environment.