### PR TITLE
Enter bootloader if RESET pressed twice, ignore PROGRAM button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CFLAGS += \
 			-D USB_PRODUCT_ID=0x615c \
 			-D USB_VENDOR_ID=0x1d50 \
 			-D USB_MANUFACTURER_STR='"Great Scott Gadgets"' \
-			-D USB_PRODUCT_STR='"Cynthion Saturn-V Bootloader"' \
+			-D USB_PRODUCT_STR='"Cynthion Saturn-V"' \
 			-D_BOARD_REVISION_MAJOR_=$(BOARD_REVISION_MAJOR) \
 			-D_BOARD_REVISION_MINOR_=$(BOARD_REVISION_MINOR)
 


### PR DESCRIPTION
This is experimental. It allows the user to start up Apollo while holding PROGRAM. It also should make it easier to use Saturn-V on QT Py or other boards that lack a second button.

The product string is shortened as a hack to save space, but that could probably be restored if I were using a newer compiler.