### PR TITLE
Enter bootloader with button only on power-on

### DIFF
--- a/main.c
+++ b/main.c
@@ -143,7 +143,8 @@ bool button_pressed(void)
 
 
 void main_bl(void) {
-	if (!flash_valid() || button_pressed() || bootloader_sw_triggered()) {
+	uint32_t reason = PM->RCAUSE.reg;
+	if (!flash_valid() || (reason & PM_RCAUSE_WDT) || ((reason & PM_RCAUSE_POR) && button_pressed())) {
 		bootloader_main();
 	}
 


### PR DESCRIPTION
This allows the application firmware to use the button at reset if the reset was triggered by something other than power-on (POR).