### PR TITLE
Fix DFU programming with WinUSB hosts

### DIFF
--- a/main.c
+++ b/main.c
@@ -87,6 +87,7 @@ void bootloader_main(void)
 								 PORT_WRCONFIG_PMUX(PORT_PMUX_PMUXE_G_Val));
 
 	usb_init();
+	dfu_reset();
 	usb_attach();
 
 	// Blink while we're in DFU mode.

--- a/usb.c
+++ b/usb.c
@@ -255,7 +255,7 @@ char *get_serial_number_string(void)
 		}
 		bitsLeft -= 5;
 		int index = (buffer >> bitsLeft) & 0x1f;
-		buf[count] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"[index];
+		buf[count] = index + (index < 26 ? 'A' : '2');  // Base32
 	}
 
 	return buf;


### PR DESCRIPTION
Previously, DFU state was not initialized until the host explicitly configured the interface altsetting.
This "set interface 0" request is not issued when using `libusb`'s WinUSB backend.
This PR forces the initialization of the DFU state at boot.