### PR TITLE
dfu: delay manifest callback until DFU_GETSTATUS is completed

### DIFF
--- a/deps/usb/class/dfu/dfu.c
+++ b/deps/usb/class/dfu/dfu.c
@@ -32,7 +32,6 @@ void dfu_control_setup() {
 		case DFU_GETSTATUS: {
 			if (dfu_state == DFU_STATE_dfuMANIFEST_SYNC) {
 				dfu_state = DFU_STATE_dfuMANIFEST;
-				dfu_cb_manifest();
 			}
 
 			uint8_t len = usb_setup.wLength;
@@ -89,6 +88,12 @@ void dfu_control_out_completion() {
 				usb_ep0_out();
 			}
 
+			break;
+		}
+		case DFU_GETSTATUS: {
+			if (dfu_state == DFU_STATE_dfuMANIFEST) {
+				dfu_cb_manifest();
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
Make sure the USB request has been responded before the device resets to avoid timeouts.