### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+  # Run automatically every monday
+  schedule:
+    - cron: 1 12 * * 1
+
+jobs:
+  firmware:
+    strategy:
+      matrix:
+        os: ['macos-latest', 'ubuntu-latest']
+
+      # Don't cancel all builds when one fails
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Arm GNU Toolchain
+      uses: carlosperate/arm-none-eabi-gcc-action@v1
+
+    - name: Build
+      run: make
+


### PR DESCRIPTION
Adds a simple CI workflow that installs the GNU Arm toolchain on Linux and macOS and builds Saturn-V.